### PR TITLE
対応するブロック破壊時アイテムが見つからない時は最後のentryを使う、マージ時出現アイテムがコンフィグの最後まで到達したら、同じアイテム…

### DIFF
--- a/lib/game_core/stage.dart
+++ b/lib/game_core/stage.dart
@@ -299,12 +299,18 @@ class Stage {
   /// 次のマージ時出現アイテムを更新
   void _updateNextMergeItem({required World gameWorld}) {
     List<StageObjTypeLevel> tls = Config().mergeAppearObjMap.values.last;
+    bool existAppearObj = false;
     for (final entry in Config().mergeAppearObjMap.entries) {
       remainMergeCount = max(entry.key - mergedCount, 0);
       if (remainMergeCount > 0) {
         tls = entry.value;
+        existAppearObj = true;
         break;
       }
+    }
+    // コンフィグで設定した最後のエントリーなら、5回マージごとに出現するようにする(無限)
+    if (!existAppearObj) {
+      remainMergeCount = 5;
     }
     nextMergeItems.clear();
     for (final tl in tls) {
@@ -344,7 +350,7 @@ class Stage {
       }
     }
     // basePointを元に、どういうオブジェクトが出現するか決定
-    late ObjInBlock pattern;
+    ObjInBlock pattern = Config().objInBlockMap.values.last;
     int jewelLevel = 1;
     for (final objInBlock in Config().objInBlockMap.entries) {
       if (objInBlock.key.contains(basePoint)) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.2.0+1
+version: 0.2.1+1
 
 environment:
   sdk: ">=3.2.3 <4.0.0"


### PR DESCRIPTION
…が5回ごとに出現するようにするように修正。

pubspecのバージョン変更時の動作確認を兼ねてる。